### PR TITLE
Implement projections

### DIFF
--- a/internal/es-go/application/command_handler/user.go
+++ b/internal/es-go/application/command_handler/user.go
@@ -8,6 +8,10 @@ import (
 	"github.com/pascalallen/es-go/internal/es-go/infrastructure/storage"
 )
 
+type ProjectionState struct {
+	EmailAddresses map[string]string `json:"email_addresses"`
+}
+
 type RegisterUserHandler struct {
 	EventStore storage.EventStore
 }
@@ -18,7 +22,16 @@ func (h RegisterUserHandler) Handle(cmd messaging.Command) error {
 		return fmt.Errorf("invalid command type passed to RegisterUserHandler: %v", cmd)
 	}
 
-	// TODO: Unique email constraint
+	var result ProjectionState
+	if err := h.EventStore.UnmarshalProjectionResult("user-email-addresses", &result); err != nil {
+		return fmt.Errorf("error getting projection result: %v", err)
+	}
+
+	for emailAddress := range result.EmailAddresses {
+		if emailAddress == c.EmailAddress {
+			return fmt.Errorf("email address %s is already registered", c.EmailAddress)
+		}
+	}
 
 	registerEvent := event.UserRegistered{
 		Id:           c.Id,
@@ -45,7 +58,16 @@ func (h UpdateUserEmailAddressHandler) Handle(cmd messaging.Command) error {
 		return fmt.Errorf("invalid command type passed to UpdateUserEmailAddressHandler: %v", cmd)
 	}
 
-	// TODO: Unique email constraint
+	var result ProjectionState
+	if err := h.EventStore.UnmarshalProjectionResult("user-email-addresses", &result); err != nil {
+		return fmt.Errorf("error getting projection result: %v", err)
+	}
+
+	for emailAddress := range result.EmailAddresses {
+		if emailAddress == c.EmailAddress {
+			return fmt.Errorf("could not update user. email address %s is already taken", c.EmailAddress)
+		}
+	}
 
 	emailUpdateEvent := event.UserEmailAddressUpdated{
 		Id:           c.Id,

--- a/internal/es-go/infrastructure/storage/event.go
+++ b/internal/es-go/infrastructure/storage/event.go
@@ -1,0 +1,5 @@
+package storage
+
+type Event interface {
+	EventName() string
+}


### PR DESCRIPTION
Configure EventStoreDB to use projections. Define projection for user email addresses and use projection for unique email constraint in command handlers.