### PR TITLE
ES/DDD/CQRS audit: fix pattern violations and complete domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,130 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Maintenance
+
+When new event types, commands, or infrastructure patterns are added, run `/claude-md-improver` to keep this file current.
+
+## Overview
+
+`es-go` is a reference implementation of Event Sourcing (ES) and Domain-Driven Design (DDD) in Go. The entire development environment runs inside Docker — Go code is executed inside the `go` container with EventStoreDB and RabbitMQ as backing services.
+
+## Commands
+
+All commands run against the Docker environment via the `bin/` scripts:
+
+```bash
+bin/up                   # Build images and start all containers (tails logs)
+bin/down                 # Stop and remove containers
+bin/exec <cmd>           # Run any command inside the go container
+```
+
+Run tests (inside the container):
+```bash
+bin/exec go test ./...
+```
+
+Run a single package's tests:
+```bash
+bin/exec go test github.com/pascalallen/es-go/internal/es-go/application/command/...
+```
+
+Run tests with coverage:
+```bash
+bin/exec go test ./... -covermode=count -coverprofile=coverage.out
+bin/exec go tool cover -html=coverage.out -o coverage.html
+```
+
+Build the binary:
+```bash
+bin/exec go build -C cmd/es-go
+```
+
+## Architecture
+
+### Layers
+
+```
+cmd/es-go/           — entrypoint: wires container, registers commands/queries/projections, starts consumers
+internal/es-go/
+  domain/            — pure domain types
+    email/           — EmailAddress value object (RFC 5322 validation)
+    event/           — Event interface + all domain event structs (UserRegistered, UserEmailAddressUpdated,
+                       UserPasswordSet, UserRoleAssigned, UserDeleted); every event has OccurredAt time.Time
+    password/        — bcrypt Hash value type
+    permission/      — Permission value type
+    role/            — Role value type
+    user/            — User aggregate: Register factory, UpdateEmailAddress, SetPassword, AssignRole, Delete
+  application/
+    command/         — command structs (RegisterUser, UpdateUserEmailAddress, AssignRoleToUser, DeleteUser)
+    command_handler/ — handlers: load aggregate → call method → AppendToStream(streamId, version, events)
+    query/           — query structs (GetUserById)
+    query_handler/   — handlers: ReadFromStream → LoadUserFromEvents → return aggregate
+    projection/      — JS projection scripts run inside EventStoreDB
+  infrastructure/
+    messaging/       — RabbitMQ command bus (async) and synchronous query bus
+    storage/         — EventStoreDB client wrapper (EventStore interface + EventStoreDb impl)
+```
+
+### Key patterns
+
+**Aggregate factory + uncommitted events (DDD/ES):**
+- `user.Register(...)` is the only way to create a User; it raises a `UserRegistered` event internally
+- Aggregate methods (`UpdateEmailAddress`, `SetPassword`, `AssignRole`, `Delete`) call the internal `raise()` helper
+- `raise()` mutates state and appends to `uncommittedEvents` but does NOT increment `version`
+- `LoadUserFromEvents` replays events via `applyEvent()` which mutates state AND increments `version`
+- Command handlers: call aggregate method → `AppendToStream(streamId, u.Version(), u.UncommittedEvents())` → `ClearUncommittedEvents()`
+
+**Optimistic concurrency via aggregate version:**
+- `User.version` starts at `-1`. After loading N events: `version == N-1` (EventStoreDB's 0-based revision)
+- `AppendToStream` maps `-1` → `esdb.NoStream`, `≥ 0` → `esdb.Revision(version)`
+- No read-before-write round trip
+
+**Deterministic event replay:**
+- Every event struct carries `OccurredAt time.Time` set at raise-time
+- `applyEventState` reads `OccurredAt` for `CreatedAt`/`ModifiedAt`/`DeletedAt` — never calls `time.Now()`
+
+**Dependency direction:**
+- `domain/event` defines the `Event` interface
+- `infrastructure/storage` imports `domain/event` — never the reverse
+
+### CQRS + Event Sourcing flow
+
+**Commands** (async via RabbitMQ):
+1. `CommandBus.Execute` serializes the command and publishes it to the `commands` queue
+2. `CommandBus.StartConsuming` deserializes and dispatches to the registered `CommandHandler`
+3. The handler validates invariants (e.g., unique email via projection), then calls an aggregate method
+4. The aggregate raises events into `uncommittedEvents`
+5. The handler calls `EventStore.AppendToStream(streamId, u.Version(), u.UncommittedEvents())`
+6. Stream IDs follow the pattern `user-{ulid}`
+
+**Queries** (synchronous):
+1. `QueryBus.Fetch` dispatches directly to the registered `QueryHandler`
+2. The handler calls `EventStore.ReadFromStream`, then `user.LoadUserFromEvents` to rebuild state
+
+**Projections** (run inside EventStoreDB):
+- Written as JavaScript and registered at startup via `EventStore.RegisterProjection`
+- Currently used for the `user-email-addresses` unique constraint
+
+### Dependency injection
+
+Uses [Google Wire](https://github.com/google/wire). `wire.go` is the injector (build-tagged `wireinject`); `wire_gen.go` is the generated output. Run `wire` inside the `cmd/es-go` directory to regenerate after modifying providers.
+
+### Adding a new event type
+
+New events require changes in these places:
+1. Define the event struct in `internal/es-go/domain/event/user.go` with `EventName()` and `OccurredAt time.Time`
+2. Add an `applyEventState` case in `domain/user/user.go`
+3. Add a `case` in `EventStoreDb.ReadFromStream` (`infrastructure/storage/event_store.go`)
+4. Add the corresponding aggregate method in `domain/user/user.go`
+5. Add a `case` in `RabbitMqCommandBus.processCommand` (`infrastructure/messaging/command_bus.go`) if triggered by a new command
+6. Register the command handler in `main.go`
+
+### Environment variables
+
+Copy `.env.example` to `.env`. Key variables consumed by the Go app:
+- `EVENTSTORE_HOST`, `EVENTSTORE_HTTP_PORT` — EventStoreDB connection
+- `RABBITMQ_HOST`, `RABBITMQ_PORT`, `RABBITMQ_DEFAULT_USER`, `RABBITMQ_DEFAULT_PASS` — RabbitMQ connection
+
+EventStoreDB UI is available at `http://localhost:2113`; RabbitMQ management UI at `http://localhost:15672`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # es-go
+#### Video Demo: https://youtu.be/Awd_VSUkUVo
+#### Description:
+es-go is open source software offering a set of guidelines to use Event Sourcing (ES), Command Query Responsibility Segregation (CQRS), and Domain-Driven Design (DDD) in Go. It uses EventStoreDB for event persistence and projections, and RabbitMQ for async command dispatch.
 
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/pascalallen/es-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/pascalallen/es-go)](https://goreportcard.com/report/github.com/pascalallen/es-go)
@@ -7,9 +10,6 @@
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/pascalallen/es-go)
 
 ![Logo](web/static/logo.svg)
-
-es-go is open source software offering a set of guidelines to use Event Sourcing and Domain-Driven Design in Go. 
-This is a living project and is subject to change.
 
 ## Prerequisites
 
@@ -34,7 +34,7 @@ cp .env.example .env
 
 ```bash
 bin/up
-``` 
+```
 
 ### Take Down Environment
 
@@ -42,17 +42,122 @@ bin/up
 bin/down
 ```
 
+### Run Commands Inside the Container
+
+All Go commands (build, test, etc.) run inside the `go` container via `bin/exec`:
+
+```bash
+bin/exec <command>
+```
+
+### Service UIs
+
+| Service | URL |
+|---|---|
+| EventStoreDB | http://localhost:2113 |
+| RabbitMQ | http://localhost:15672 |
+
+## Architecture
+
+### Patterns
+
+| Pattern | Description |
+|---|---|
+| **Event Sourcing** | All state changes are stored as an immutable sequence of domain events. State is reconstructed by replaying those events. |
+| **CQRS** | Commands (writes) flow async through RabbitMQ; queries (reads) are dispatched synchronously and rebuild state from events. |
+| **DDD** | The `User` aggregate owns all invariants. External code never creates domain events directly — it calls aggregate methods. |
+
+### Layers
+
+```
+cmd/es-go/           — entry point: wires container, registers commands/queries/projections, starts consumers
+internal/es-go/
+  domain/
+    email/           — EmailAddress value object (validates RFC 5322 format)
+    event/           — Event interface + all domain event structs (OccurredAt on every event)
+    password/        — bcrypt Hash value type
+    permission/      — Permission value type
+    role/            — Role value type
+    user/            — User aggregate (Register factory, UpdateEmailAddress, SetPassword, AssignRole, Delete)
+  application/
+    command/         — command structs (RegisterUser, UpdateUserEmailAddress, AssignRoleToUser, DeleteUser)
+    command_handler/ — handlers: load aggregate → call method → AppendToStream with aggregate version
+    query/           — query structs (GetUserById)
+    query_handler/   — handlers: ReadFromStream → LoadUserFromEvents → return aggregate
+    projection/      — EventStoreDB JS projection scripts (user-email-addresses unique constraint)
+  infrastructure/
+    messaging/       — RabbitMQ command bus (async) and synchronous query bus
+    storage/         — EventStoreDB client (EventStore interface, EventStoreDb impl)
+```
+
+### CQRS + Event Sourcing flow
+
+**Commands** (async via RabbitMQ):
+1. `CommandBus.Execute` serializes the command and publishes it to the `commands` queue
+2. `CommandBus.StartConsuming` deserializes and dispatches to the registered `CommandHandler`
+3. The handler validates invariants (e.g., unique email via projection), then calls an aggregate method
+4. The aggregate raises events into its `uncommittedEvents` slice (write path does not increment version)
+5. The handler calls `EventStore.AppendToStream(streamId, u.Version(), u.UncommittedEvents())`
+6. `AppendToStream` uses the aggregate's version for optimistic concurrency (`-1` → `NoStream`, `≥ 0` → `Revision(version)`)
+7. Stream IDs follow the pattern `user-{ulid}`
+
+**Queries** (synchronous):
+1. `QueryBus.Fetch` dispatches directly to the registered `QueryHandler`
+2. The handler calls `EventStore.ReadFromStream`, which returns all events for the stream
+3. `user.LoadUserFromEvents` replays events to rebuild aggregate state; each applied event increments `version`
+
+**Projections** (run inside EventStoreDB):
+- Written as JavaScript and registered at startup via `EventStore.RegisterProjection`
+- Listen to event categories and maintain queryable state
+- Used for the `user-email-addresses` unique constraint
+
+### Aggregate versioning and optimistic concurrency
+
+`User.version` starts at `-1` (no events persisted). Each event applied during `LoadUserFromEvents` increments it. After loading N events, `version == N-1`, matching EventStoreDB's 0-based stream revision of the last persisted event.
+
+On the write path, aggregate methods call the internal `raise()` helper which mutates state and queues the event but does **not** increment `version`. This means `u.Version()` always reflects the last **persisted** revision — the correct value to pass as `expectedVersion` to `AppendToStream`.
+
+### Dependency injection
+
+Uses [Google Wire](https://github.com/google/wire). `wire.go` is the injector (build-tagged `wireinject`); `wire_gen.go` is the generated output. Run `wire` inside the `cmd/es-go` directory to regenerate after modifying providers.
+
+### Adding a new event type
+
+New events require changes in these places:
+
+1. Define the event struct in `internal/es-go/domain/event/user.go` with `EventName()` and `OccurredAt time.Time`
+2. Add an `applyEventState` case in `domain/user/user.go`
+3. Add a `case` in `EventStoreDb.ReadFromStream` (`infrastructure/storage/event_store.go`)
+4. Add the corresponding aggregate method (or update an existing one) in `domain/user/user.go`
+5. Add a `case` in `RabbitMqCommandBus.processCommand` (`infrastructure/messaging/command_bus.go`) if triggered by a new command
+6. Register the command handler in `main.go`
+
+### Environment variables
+
+Copy `.env.example` to `.env`. Key variables consumed by the Go app:
+- `EVENTSTORE_HOST`, `EVENTSTORE_HTTP_PORT` — EventStoreDB connection
+- `RABBITMQ_HOST`, `RABBITMQ_PORT`, `RABBITMQ_DEFAULT_USER`, `RABBITMQ_DEFAULT_PASS` — RabbitMQ connection
+
+EventStoreDB UI is available at `http://localhost:2113`; RabbitMQ management UI at `http://localhost:15672`.
+
 ## Testing
 
-Run tests and create coverage profile:
+Run all tests:
+
+```bash
+bin/exec go test ./...
+```
+
+Run a single package's tests:
+
+```bash
+bin/exec go test github.com/pascalallen/es-go/internal/es-go/application/command/...
+```
+
+Run tests and generate a coverage profile:
 
 ```bash
 bin/exec go test ./... -covermode=count -coverprofile=coverage.out
-```
-
-Generate HTML file to view test coverage profile:
-
-```bash
 bin/exec go tool cover -html=coverage.out -o coverage.html
 ```
 

--- a/cmd/es-go/main.go
+++ b/cmd/es-go/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pascalallen/es-go/internal/es-go/application/projection"
 	"github.com/pascalallen/es-go/internal/es-go/application/query"
 	"github.com/pascalallen/es-go/internal/es-go/application/query_handler"
+	"github.com/pascalallen/es-go/internal/es-go/domain/role"
 	"log"
 	"time"
 )
@@ -26,7 +27,6 @@ func main() {
 func setupProjections(container Container) {
 	eventStore := container.EventStore
 
-	// projection registry
 	err := eventStore.RegisterProjection(projection.UserEmailAddresses{})
 	if err != nil {
 		exitOnError(err)
@@ -38,11 +38,11 @@ func runConsumers(container Container) {
 	queryBus := container.QueryBus
 	eventStore := container.EventStore
 
-	// command registry
 	commandBus.RegisterHandler(command.RegisterUser{}.CommandName(), command_handler.RegisterUserHandler{EventStore: eventStore})
 	commandBus.RegisterHandler(command.UpdateUserEmailAddress{}.CommandName(), command_handler.UpdateUserEmailAddressHandler{EventStore: eventStore})
+	commandBus.RegisterHandler(command.AssignRoleToUser{}.CommandName(), command_handler.AssignRoleToUserHandler{EventStore: eventStore})
+	commandBus.RegisterHandler(command.DeleteUser{}.CommandName(), command_handler.DeleteUserHandler{EventStore: eventStore})
 
-	// query registry
 	queryBus.RegisterHandler(query.GetUserById{}.QueryName(), query_handler.GetUserByIdHandler{EventStore: eventStore})
 
 	go commandBus.StartConsuming()
@@ -52,31 +52,43 @@ func tempAppExecution(container Container) {
 	time.Sleep(time.Second * 3)
 
 	userId := ulid.Make()
+	adminRole := role.Role{
+		Id:        ulid.Make(),
+		Name:      "admin",
+		CreatedAt: time.Now(),
+	}
 
 	go func() {
-		// simulate user registration
-		registerUserCommand := command.RegisterUser{
+		err := container.CommandBus.Execute(command.RegisterUser{
 			Id:           userId,
 			FirstName:    "Pascal",
 			LastName:     "Allen",
 			EmailAddress: "pascal@allen.com",
-		}
-		err := container.CommandBus.Execute(registerUserCommand)
+			Password:     "pa$$w0rd",
+		})
 		exitOnError(err)
 
-		// simulate email address update
-		updateUserEmailCommand := command.UpdateUserEmailAddress{
+		err = container.CommandBus.Execute(command.UpdateUserEmailAddress{
 			Id:           userId,
 			EmailAddress: "thomas@allen.com",
-		}
-		err = container.CommandBus.Execute(updateUserEmailCommand)
+		})
+		exitOnError(err)
+
+		err = container.CommandBus.Execute(command.AssignRoleToUser{
+			Id:   userId,
+			Role: adminRole,
+		})
+		exitOnError(err)
+
+		err = container.CommandBus.Execute(command.DeleteUser{
+			Id: userId,
+		})
 		exitOnError(err)
 	}()
 
 	time.Sleep(time.Second * 3)
 
 	go func() {
-		// simulate querying for user by ID
 		getUserByIdQuery := query.GetUserById{Id: userId}
 		u, err := container.QueryBus.Fetch(getUserByIdQuery)
 		log.Printf("[[[ USER BUILT FROM EVENTS ]]]: %v\n", u)

--- a/internal/es-go/application/command/user.go
+++ b/internal/es-go/application/command/user.go
@@ -1,12 +1,16 @@
 package command
 
-import "github.com/oklog/ulid/v2"
+import (
+	"github.com/oklog/ulid/v2"
+	"github.com/pascalallen/es-go/internal/es-go/domain/role"
+)
 
 type RegisterUser struct {
 	Id           ulid.ULID `json:"id"`
 	FirstName    string    `json:"first_name"`
 	LastName     string    `json:"last_name"`
 	EmailAddress string    `json:"email_address"`
+	Password     string    `json:"password"`
 }
 
 func (c RegisterUser) CommandName() string {
@@ -20,4 +24,21 @@ type UpdateUserEmailAddress struct {
 
 func (c UpdateUserEmailAddress) CommandName() string {
 	return "UpdateUserEmailAddress"
+}
+
+type AssignRoleToUser struct {
+	Id   ulid.ULID `json:"id"`
+	Role role.Role `json:"role"`
+}
+
+func (c AssignRoleToUser) CommandName() string {
+	return "AssignRoleToUser"
+}
+
+type DeleteUser struct {
+	Id ulid.ULID `json:"id"`
+}
+
+func (c DeleteUser) CommandName() string {
+	return "DeleteUser"
 }

--- a/internal/es-go/application/command/user_test.go
+++ b/internal/es-go/application/command/user_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"github.com/oklog/ulid/v2"
+	"github.com/pascalallen/es-go/internal/es-go/domain/role"
 	"testing"
 )
 
@@ -11,8 +12,8 @@ func TestThatCommandNameReturnsExpectedValueRegisterUser(t *testing.T) {
 		FirstName:    "Pascal",
 		LastName:     "Allen",
 		EmailAddress: "pascal@allen.com",
+		Password:     "pa$$w0rd",
 	}
-
 	if cmd.CommandName() != "RegisterUser" {
 		t.Fatal("test assertion failed for RegisterUser.CommandName()")
 	}
@@ -26,5 +27,24 @@ func TestThatCommandNameReturnsExpectedValueUpdateUserEmailAddress(t *testing.T)
 
 	if cmd.CommandName() != "UpdateUserEmailAddress" {
 		t.Fatal("test assertion failed for UpdateUserEmailAddress.CommandName()")
+	}
+}
+
+func TestThatCommandNameReturnsExpectedValueAssignRoleToUser(t *testing.T) {
+	cmd := AssignRoleToUser{
+		Id:   ulid.Make(),
+		Role: role.Role{Id: ulid.Make(), Name: "admin"},
+	}
+	if cmd.CommandName() != "AssignRoleToUser" {
+		t.Fatal("test assertion failed for AssignRoleToUser.CommandName()")
+	}
+}
+
+func TestThatCommandNameReturnsExpectedValueDeleteUser(t *testing.T) {
+	cmd := DeleteUser{
+		Id: ulid.Make(),
+	}
+	if cmd.CommandName() != "DeleteUser" {
+		t.Fatal("test assertion failed for DeleteUser.CommandName()")
 	}
 }

--- a/internal/es-go/application/command_handler/projection_state.go
+++ b/internal/es-go/application/command_handler/projection_state.go
@@ -1,0 +1,5 @@
+package command_handler
+
+type ProjectionState struct {
+	EmailAddresses map[string]string `json:"email_addresses"`
+}

--- a/internal/es-go/application/command_handler/user.go
+++ b/internal/es-go/application/command_handler/user.go
@@ -3,14 +3,12 @@ package command_handler
 import (
 	"fmt"
 	"github.com/pascalallen/es-go/internal/es-go/application/command"
-	"github.com/pascalallen/es-go/internal/es-go/domain/event"
+	"github.com/pascalallen/es-go/internal/es-go/domain/email"
+	"github.com/pascalallen/es-go/internal/es-go/domain/password"
+	"github.com/pascalallen/es-go/internal/es-go/domain/user"
 	"github.com/pascalallen/es-go/internal/es-go/infrastructure/messaging"
 	"github.com/pascalallen/es-go/internal/es-go/infrastructure/storage"
 )
-
-type ProjectionState struct {
-	EmailAddresses map[string]string `json:"email_addresses"`
-}
 
 type RegisterUserHandler struct {
 	EventStore storage.EventStore
@@ -26,24 +24,29 @@ func (h RegisterUserHandler) Handle(cmd messaging.Command) error {
 	if err := h.EventStore.UnmarshalProjectionResult("user-email-addresses", &result); err != nil {
 		return fmt.Errorf("error getting projection result: %v", err)
 	}
-
 	for emailAddress := range result.EmailAddresses {
 		if emailAddress == c.EmailAddress {
 			return fmt.Errorf("email address %s is already registered", c.EmailAddress)
 		}
 	}
 
-	registerEvent := event.UserRegistered{
-		Id:           c.Id,
-		FirstName:    c.FirstName,
-		LastName:     c.LastName,
-		EmailAddress: c.EmailAddress,
-	}
-	streamId := fmt.Sprintf("user-%s", c.Id)
-	err := h.EventStore.AppendToStream(streamId, registerEvent)
+	addr, err := email.New(c.EmailAddress)
 	if err != nil {
-		return fmt.Errorf("could not store UserRegistered event: %w", err)
+		return fmt.Errorf("invalid email address: %w", err)
 	}
+
+	hash := password.Create(c.Password)
+
+	u, err := user.Register(c.Id, c.FirstName, c.LastName, addr, hash)
+	if err != nil {
+		return fmt.Errorf("could not register user: %w", err)
+	}
+
+	streamId := fmt.Sprintf("user-%s", c.Id)
+	if err := h.EventStore.AppendToStream(streamId, u.Version(), u.UncommittedEvents()); err != nil {
+		return fmt.Errorf("could not store events: %w", err)
+	}
+	u.ClearUncommittedEvents()
 
 	return nil
 }
@@ -62,22 +65,93 @@ func (h UpdateUserEmailAddressHandler) Handle(cmd messaging.Command) error {
 	if err := h.EventStore.UnmarshalProjectionResult("user-email-addresses", &result); err != nil {
 		return fmt.Errorf("error getting projection result: %v", err)
 	}
-
 	for emailAddress := range result.EmailAddresses {
 		if emailAddress == c.EmailAddress {
 			return fmt.Errorf("could not update user. email address %s is already taken", c.EmailAddress)
 		}
 	}
 
-	emailUpdateEvent := event.UserEmailAddressUpdated{
-		Id:           c.Id,
-		EmailAddress: c.EmailAddress,
-	}
-	streamId := fmt.Sprintf("user-%s", c.Id)
-	err := h.EventStore.AppendToStream(streamId, emailUpdateEvent)
+	addr, err := email.New(c.EmailAddress)
 	if err != nil {
-		return fmt.Errorf("could not store UserEmailAddressUpdated event: %w", err)
+		return fmt.Errorf("invalid email address: %w", err)
 	}
+
+	streamId := fmt.Sprintf("user-%s", c.Id)
+	events, err := h.EventStore.ReadFromStream(streamId)
+	if err != nil {
+		return fmt.Errorf("error reading user stream: %w", err)
+	}
+
+	u := user.LoadUserFromEvents(events)
+
+	if err := u.UpdateEmailAddress(addr); err != nil {
+		return fmt.Errorf("could not update email address: %w", err)
+	}
+
+	if err := h.EventStore.AppendToStream(streamId, u.Version(), u.UncommittedEvents()); err != nil {
+		return fmt.Errorf("could not store events: %w", err)
+	}
+	u.ClearUncommittedEvents()
+
+	return nil
+}
+
+type AssignRoleToUserHandler struct {
+	EventStore storage.EventStore
+}
+
+func (h AssignRoleToUserHandler) Handle(cmd messaging.Command) error {
+	c, ok := cmd.(*command.AssignRoleToUser)
+	if !ok {
+		return fmt.Errorf("invalid command type passed to AssignRoleToUserHandler: %v", cmd)
+	}
+
+	streamId := fmt.Sprintf("user-%s", c.Id)
+	events, err := h.EventStore.ReadFromStream(streamId)
+	if err != nil {
+		return fmt.Errorf("error reading user stream: %w", err)
+	}
+
+	u := user.LoadUserFromEvents(events)
+
+	if err := u.AssignRole(c.Role); err != nil {
+		return fmt.Errorf("could not assign role: %w", err)
+	}
+
+	if err := h.EventStore.AppendToStream(streamId, u.Version(), u.UncommittedEvents()); err != nil {
+		return fmt.Errorf("could not store events: %w", err)
+	}
+	u.ClearUncommittedEvents()
+
+	return nil
+}
+
+type DeleteUserHandler struct {
+	EventStore storage.EventStore
+}
+
+func (h DeleteUserHandler) Handle(cmd messaging.Command) error {
+	c, ok := cmd.(*command.DeleteUser)
+	if !ok {
+		return fmt.Errorf("invalid command type passed to DeleteUserHandler: %v", cmd)
+	}
+
+	streamId := fmt.Sprintf("user-%s", c.Id)
+	events, err := h.EventStore.ReadFromStream(streamId)
+	if err != nil {
+		return fmt.Errorf("error reading user stream: %w", err)
+	}
+
+	u := user.LoadUserFromEvents(events)
+
+	if err := u.Delete(); err != nil {
+		return fmt.Errorf("could not delete user: %w", err)
+	}
+
+	if err := h.EventStore.AppendToStream(streamId, u.Version(), u.UncommittedEvents()); err != nil {
+		return fmt.Errorf("could not store events: %w", err)
+	}
+	u.ClearUncommittedEvents()
 
 	return nil
 }

--- a/internal/es-go/domain/email/email_address.go
+++ b/internal/es-go/domain/email/email_address.go
@@ -1,0 +1,23 @@
+package email
+
+import (
+	"fmt"
+	"net/mail"
+)
+
+type EmailAddress string
+
+func New(s string) (EmailAddress, error) {
+	if s == "" {
+		return "", fmt.Errorf("email address cannot be empty")
+	}
+	addr, err := mail.ParseAddress(s)
+	if err != nil {
+		return "", fmt.Errorf("invalid email address %q: %w", s, err)
+	}
+	return EmailAddress(addr.Address), nil
+}
+
+func (e EmailAddress) String() string {
+	return string(e)
+}

--- a/internal/es-go/domain/email/email_address_test.go
+++ b/internal/es-go/domain/email/email_address_test.go
@@ -1,0 +1,34 @@
+package email
+
+import "testing"
+
+func TestNewEmailAddress_ValidEmail(t *testing.T) {
+	addr, err := New("pascal@allen.com")
+	if err != nil {
+		t.Fatalf("expected no error for valid email, got: %v", err)
+	}
+	if addr.String() != "pascal@allen.com" {
+		t.Fatalf("expected 'pascal@allen.com', got '%s'", addr.String())
+	}
+}
+
+func TestNewEmailAddress_EmptyString(t *testing.T) {
+	_, err := New("")
+	if err == nil {
+		t.Fatal("expected error for empty email, got nil")
+	}
+}
+
+func TestNewEmailAddress_InvalidFormat(t *testing.T) {
+	_, err := New("not-an-email")
+	if err == nil {
+		t.Fatal("expected error for invalid email format, got nil")
+	}
+}
+
+func TestEmailAddressString(t *testing.T) {
+	addr, _ := New("pascal@allen.com")
+	if addr.String() != "pascal@allen.com" {
+		t.Fatalf("expected 'pascal@allen.com', got '%s'", addr.String())
+	}
+}

--- a/internal/es-go/domain/event/event.go
+++ b/internal/es-go/domain/event/event.go
@@ -1,0 +1,5 @@
+package event
+
+type Event interface {
+	EventName() string
+}

--- a/internal/es-go/domain/event/user.go
+++ b/internal/es-go/domain/event/user.go
@@ -1,12 +1,18 @@
 package event
 
-import "github.com/oklog/ulid/v2"
+import (
+	"github.com/oklog/ulid/v2"
+	"github.com/pascalallen/es-go/internal/es-go/domain/role"
+	"time"
+)
 
 type UserRegistered struct {
 	Id           ulid.ULID `json:"id"`
 	FirstName    string    `json:"first_name"`
 	LastName     string    `json:"last_name"`
 	EmailAddress string    `json:"email_address"`
+	PasswordHash string    `json:"password_hash"`
+	OccurredAt   time.Time `json:"occurred_at"`
 }
 
 func (e UserRegistered) EventName() string {
@@ -16,8 +22,38 @@ func (e UserRegistered) EventName() string {
 type UserEmailAddressUpdated struct {
 	Id           ulid.ULID `json:"id"`
 	EmailAddress string    `json:"email_address"`
+	OccurredAt   time.Time `json:"occurred_at"`
 }
 
 func (e UserEmailAddressUpdated) EventName() string {
 	return "UserEmailAddressUpdated"
+}
+
+type UserPasswordSet struct {
+	Id           ulid.ULID `json:"id"`
+	PasswordHash string    `json:"password_hash"`
+	OccurredAt   time.Time `json:"occurred_at"`
+}
+
+func (e UserPasswordSet) EventName() string {
+	return "UserPasswordSet"
+}
+
+type UserRoleAssigned struct {
+	Id         ulid.ULID `json:"id"`
+	Role       role.Role `json:"role"`
+	OccurredAt time.Time `json:"occurred_at"`
+}
+
+func (e UserRoleAssigned) EventName() string {
+	return "UserRoleAssigned"
+}
+
+type UserDeleted struct {
+	Id         ulid.ULID `json:"id"`
+	OccurredAt time.Time `json:"occurred_at"`
+}
+
+func (e UserDeleted) EventName() string {
+	return "UserDeleted"
 }

--- a/internal/es-go/domain/event/user_test.go
+++ b/internal/es-go/domain/event/user_test.go
@@ -2,29 +2,64 @@ package event
 
 import (
 	"github.com/oklog/ulid/v2"
+	"github.com/pascalallen/es-go/internal/es-go/domain/role"
 	"testing"
+	"time"
 )
 
 func TestThatEventNameReturnsExpectedValueUserRegistered(t *testing.T) {
-	u := UserRegistered{
+	e := UserRegistered{
 		Id:           ulid.Make(),
 		FirstName:    "Pascal",
 		LastName:     "Allen",
 		EmailAddress: "pascal@allen.com",
+		PasswordHash: "hash",
+		OccurredAt:   time.Now(),
 	}
-
-	if u.EventName() != "UserRegistered" {
+	if e.EventName() != "UserRegistered" {
 		t.Fatal("test assertion failed for UserRegistered.EventName()")
 	}
 }
 
 func TestThatEventNameReturnsExpectedValueUserEmailAddressUpdated(t *testing.T) {
-	u := UserEmailAddressUpdated{
+	e := UserEmailAddressUpdated{
 		Id:           ulid.Make(),
 		EmailAddress: "pascal@allen.com",
+		OccurredAt:   time.Now(),
 	}
-
-	if u.EventName() != "UserEmailAddressUpdated" {
+	if e.EventName() != "UserEmailAddressUpdated" {
 		t.Fatal("test assertion failed for UserEmailAddressUpdated.EventName()")
+	}
+}
+
+func TestThatEventNameReturnsExpectedValueUserPasswordSet(t *testing.T) {
+	e := UserPasswordSet{
+		Id:           ulid.Make(),
+		PasswordHash: "hash",
+		OccurredAt:   time.Now(),
+	}
+	if e.EventName() != "UserPasswordSet" {
+		t.Fatal("test assertion failed for UserPasswordSet.EventName()")
+	}
+}
+
+func TestThatEventNameReturnsExpectedValueUserRoleAssigned(t *testing.T) {
+	e := UserRoleAssigned{
+		Id:         ulid.Make(),
+		Role:       role.Role{Id: ulid.Make(), Name: "admin"},
+		OccurredAt: time.Now(),
+	}
+	if e.EventName() != "UserRoleAssigned" {
+		t.Fatal("test assertion failed for UserRoleAssigned.EventName()")
+	}
+}
+
+func TestThatEventNameReturnsExpectedValueUserDeleted(t *testing.T) {
+	e := UserDeleted{
+		Id:         ulid.Make(),
+		OccurredAt: time.Now(),
+	}
+	if e.EventName() != "UserDeleted" {
+		t.Fatal("test assertion failed for UserDeleted.EventName()")
 	}
 }

--- a/internal/es-go/domain/user/user.go
+++ b/internal/es-go/domain/user/user.go
@@ -1,49 +1,153 @@
 package user
 
 import (
+	"fmt"
 	"github.com/oklog/ulid/v2"
+	"github.com/pascalallen/es-go/internal/es-go/domain/email"
 	"github.com/pascalallen/es-go/internal/es-go/domain/event"
 	"github.com/pascalallen/es-go/internal/es-go/domain/password"
 	"github.com/pascalallen/es-go/internal/es-go/domain/role"
-	"github.com/pascalallen/es-go/internal/es-go/infrastructure/storage"
 	"time"
 )
 
 type User struct {
-	Id           ulid.ULID     `json:"id"`
-	FirstName    string        `json:"first_name"`
-	LastName     string        `json:"last_name"`
-	EmailAddress string        `json:"email_address"`
-	PasswordHash password.Hash `json:"-"`
-	Roles        []role.Role   `json:"roles"`
-	CreatedAt    time.Time     `json:"created_at"`
-	ModifiedAt   time.Time     `json:"modified_at,omitempty"`
-	DeletedAt    time.Time     `json:"deleted_at,omitempty"`
+	Id                ulid.ULID     `json:"id"`
+	FirstName         string        `json:"first_name"`
+	LastName          string        `json:"last_name"`
+	EmailAddress      string        `json:"email_address"`
+	PasswordHash      password.Hash `json:"-"`
+	Roles             []role.Role   `json:"roles"`
+	CreatedAt         time.Time     `json:"created_at"`
+	ModifiedAt        time.Time     `json:"modified_at,omitempty"`
+	DeletedAt         time.Time     `json:"deleted_at,omitempty"`
+	version           int
+	uncommittedEvents []event.Event
 }
 
-func LoadUserFromEvents(events []storage.Event) *User {
-	u := &User{}
+func Register(id ulid.ULID, firstName, lastName string, addr email.EmailAddress, hash password.Hash) (*User, error) {
+	if firstName == "" {
+		return nil, fmt.Errorf("first name cannot be empty")
+	}
+	if lastName == "" {
+		return nil, fmt.Errorf("last name cannot be empty")
+	}
+	u := &User{version: -1}
+	u.raise(&event.UserRegistered{
+		Id:           id,
+		FirstName:    firstName,
+		LastName:     lastName,
+		EmailAddress: addr.String(),
+		PasswordHash: string(hash),
+		OccurredAt:   time.Now(),
+	})
+	return u, nil
+}
 
+func LoadUserFromEvents(events []event.Event) *User {
+	u := &User{version: -1}
 	for _, evt := range events {
 		u.applyEvent(evt)
 	}
-
 	return u
 }
 
-func (u *User) applyEvent(evt storage.Event) {
-	switch evt.EventName() {
-	case event.UserRegistered{}.EventName():
-		e := evt.(*event.UserRegistered)
+func (u *User) UpdateEmailAddress(addr email.EmailAddress) error {
+	if !u.DeletedAt.IsZero() {
+		return fmt.Errorf("cannot update email address of a deleted user")
+	}
+	u.raise(&event.UserEmailAddressUpdated{
+		Id:           u.Id,
+		EmailAddress: addr.String(),
+		OccurredAt:   time.Now(),
+	})
+	return nil
+}
+
+func (u *User) SetPassword(hash password.Hash) error {
+	if !u.DeletedAt.IsZero() {
+		return fmt.Errorf("cannot set password of a deleted user")
+	}
+	u.raise(&event.UserPasswordSet{
+		Id:           u.Id,
+		PasswordHash: string(hash),
+		OccurredAt:   time.Now(),
+	})
+	return nil
+}
+
+func (u *User) AssignRole(r role.Role) error {
+	if !u.DeletedAt.IsZero() {
+		return fmt.Errorf("cannot assign role to a deleted user")
+	}
+	for _, existing := range u.Roles {
+		if existing.Id == r.Id {
+			return fmt.Errorf("role %s is already assigned to this user", r.Name)
+		}
+	}
+	u.raise(&event.UserRoleAssigned{
+		Id:         u.Id,
+		Role:       r,
+		OccurredAt: time.Now(),
+	})
+	return nil
+}
+
+func (u *User) Delete() error {
+	if !u.DeletedAt.IsZero() {
+		return fmt.Errorf("user is already deleted")
+	}
+	u.raise(&event.UserDeleted{
+		Id:         u.Id,
+		OccurredAt: time.Now(),
+	})
+	return nil
+}
+
+func (u *User) Version() int {
+	return u.version
+}
+
+func (u *User) UncommittedEvents() []event.Event {
+	return u.uncommittedEvents
+}
+
+func (u *User) ClearUncommittedEvents() {
+	u.uncommittedEvents = nil
+}
+
+// raise is the write-path helper: mutates state and queues the event for persistence.
+// It does NOT increment version — version only changes on the replay path (applyEvent).
+func (u *User) raise(evt event.Event) {
+	u.applyEventState(evt)
+	u.uncommittedEvents = append(u.uncommittedEvents, evt)
+}
+
+// applyEvent is the read-path helper: mutates state and increments version.
+// Called only by LoadUserFromEvents during event replay.
+func (u *User) applyEvent(evt event.Event) {
+	u.applyEventState(evt)
+	u.version++
+}
+
+func (u *User) applyEventState(evt event.Event) {
+	switch e := evt.(type) {
+	case *event.UserRegistered:
 		u.Id = e.Id
 		u.FirstName = e.FirstName
 		u.LastName = e.LastName
 		u.EmailAddress = e.EmailAddress
-		u.CreatedAt = time.Now()
-	case event.UserEmailAddressUpdated{}.EventName():
-		e := evt.(*event.UserEmailAddressUpdated)
-		u.Id = e.Id
+		u.PasswordHash = password.Hash(e.PasswordHash)
+		u.CreatedAt = e.OccurredAt
+	case *event.UserEmailAddressUpdated:
 		u.EmailAddress = e.EmailAddress
-		u.ModifiedAt = time.Now()
+		u.ModifiedAt = e.OccurredAt
+	case *event.UserPasswordSet:
+		u.PasswordHash = password.Hash(e.PasswordHash)
+		u.ModifiedAt = e.OccurredAt
+	case *event.UserRoleAssigned:
+		u.Roles = append(u.Roles, e.Role)
+		u.ModifiedAt = e.OccurredAt
+	case *event.UserDeleted:
+		u.DeletedAt = e.OccurredAt
 	}
 }

--- a/internal/es-go/domain/user/user_test.go
+++ b/internal/es-go/domain/user/user_test.go
@@ -1,0 +1,224 @@
+package user
+
+import (
+	"github.com/oklog/ulid/v2"
+	"github.com/pascalallen/es-go/internal/es-go/domain/email"
+	"github.com/pascalallen/es-go/internal/es-go/domain/event"
+	"github.com/pascalallen/es-go/internal/es-go/domain/password"
+	"github.com/pascalallen/es-go/internal/es-go/domain/role"
+	"testing"
+	"time"
+)
+
+func TestUserRegister_HappyPath(t *testing.T) {
+	id := ulid.Make()
+	addr, _ := email.New("pascal@allen.com")
+	hash := password.Create("pa$$w0rd")
+
+	u, err := Register(id, "Pascal", "Allen", addr, hash)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if u.Id != id {
+		t.Fatalf("expected Id %v, got %v", id, u.Id)
+	}
+	if u.FirstName != "Pascal" {
+		t.Fatalf("expected FirstName 'Pascal', got '%s'", u.FirstName)
+	}
+	if u.LastName != "Allen" {
+		t.Fatalf("expected LastName 'Allen', got '%s'", u.LastName)
+	}
+	if u.EmailAddress != "pascal@allen.com" {
+		t.Fatalf("expected EmailAddress 'pascal@allen.com', got '%s'", u.EmailAddress)
+	}
+	if len(u.UncommittedEvents()) != 1 {
+		t.Fatalf("expected 1 uncommitted event, got %d", len(u.UncommittedEvents()))
+	}
+	if _, ok := u.UncommittedEvents()[0].(*event.UserRegistered); !ok {
+		t.Fatal("expected first uncommitted event to be *event.UserRegistered")
+	}
+	if u.Version() != -1 {
+		t.Fatalf("expected version -1 after Register (nothing persisted), got %d", u.Version())
+	}
+}
+
+func TestUserRegister_EmptyFirstName(t *testing.T) {
+	addr, _ := email.New("pascal@allen.com")
+	hash := password.Create("pa$$w0rd")
+
+	_, err := Register(ulid.Make(), "", "Allen", addr, hash)
+	if err == nil {
+		t.Fatal("expected error for empty first name, got nil")
+	}
+}
+
+func TestUserRegister_EmptyLastName(t *testing.T) {
+	addr, _ := email.New("pascal@allen.com")
+	hash := password.Create("pa$$w0rd")
+
+	_, err := Register(ulid.Make(), "Pascal", "", addr, hash)
+	if err == nil {
+		t.Fatal("expected error for empty last name, got nil")
+	}
+}
+
+func TestUserUpdateEmailAddress_HappyPath(t *testing.T) {
+	id := ulid.Make()
+	addr, _ := email.New("pascal@allen.com")
+	hash := password.Create("pa$$w0rd")
+	u, _ := Register(id, "Pascal", "Allen", addr, hash)
+	u.ClearUncommittedEvents()
+
+	newAddr, _ := email.New("thomas@allen.com")
+	err := u.UpdateEmailAddress(newAddr)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if u.EmailAddress != "thomas@allen.com" {
+		t.Fatalf("expected 'thomas@allen.com', got '%s'", u.EmailAddress)
+	}
+	if len(u.UncommittedEvents()) != 1 {
+		t.Fatalf("expected 1 uncommitted event, got %d", len(u.UncommittedEvents()))
+	}
+	if _, ok := u.UncommittedEvents()[0].(*event.UserEmailAddressUpdated); !ok {
+		t.Fatal("expected uncommitted event to be *event.UserEmailAddressUpdated")
+	}
+}
+
+func TestUserUpdateEmailAddress_AlreadyDeleted(t *testing.T) {
+	addr, _ := email.New("pascal@allen.com")
+	hash := password.Create("pa$$w0rd")
+	u, _ := Register(ulid.Make(), "Pascal", "Allen", addr, hash)
+	_ = u.Delete()
+
+	newAddr, _ := email.New("thomas@allen.com")
+	err := u.UpdateEmailAddress(newAddr)
+	if err == nil {
+		t.Fatal("expected error when updating deleted user, got nil")
+	}
+}
+
+func TestUserSetPassword_HappyPath(t *testing.T) {
+	addr, _ := email.New("pascal@allen.com")
+	hash := password.Create("pa$$w0rd")
+	u, _ := Register(ulid.Make(), "Pascal", "Allen", addr, hash)
+	u.ClearUncommittedEvents()
+
+	newHash := password.Create("newpa$$w0rd")
+	err := u.SetPassword(newHash)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(u.UncommittedEvents()) != 1 {
+		t.Fatalf("expected 1 uncommitted event, got %d", len(u.UncommittedEvents()))
+	}
+	if _, ok := u.UncommittedEvents()[0].(*event.UserPasswordSet); !ok {
+		t.Fatal("expected uncommitted event to be *event.UserPasswordSet")
+	}
+}
+
+func TestUserAssignRole_HappyPath(t *testing.T) {
+	addr, _ := email.New("pascal@allen.com")
+	hash := password.Create("pa$$w0rd")
+	u, _ := Register(ulid.Make(), "Pascal", "Allen", addr, hash)
+	u.ClearUncommittedEvents()
+
+	r := role.Role{Id: ulid.Make(), Name: "admin"}
+	err := u.AssignRole(r)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(u.Roles) != 1 {
+		t.Fatalf("expected 1 role, got %d", len(u.Roles))
+	}
+	if len(u.UncommittedEvents()) != 1 {
+		t.Fatalf("expected 1 uncommitted event, got %d", len(u.UncommittedEvents()))
+	}
+	if _, ok := u.UncommittedEvents()[0].(*event.UserRoleAssigned); !ok {
+		t.Fatal("expected uncommitted event to be *event.UserRoleAssigned")
+	}
+}
+
+func TestUserAssignRole_DuplicateRoleId(t *testing.T) {
+	addr, _ := email.New("pascal@allen.com")
+	hash := password.Create("pa$$w0rd")
+	u, _ := Register(ulid.Make(), "Pascal", "Allen", addr, hash)
+	r := role.Role{Id: ulid.Make(), Name: "admin"}
+	_ = u.AssignRole(r)
+	u.ClearUncommittedEvents()
+
+	err := u.AssignRole(r)
+	if err == nil {
+		t.Fatal("expected error for duplicate role ID, got nil")
+	}
+}
+
+func TestUserDelete_HappyPath(t *testing.T) {
+	addr, _ := email.New("pascal@allen.com")
+	hash := password.Create("pa$$w0rd")
+	u, _ := Register(ulid.Make(), "Pascal", "Allen", addr, hash)
+	u.ClearUncommittedEvents()
+
+	err := u.Delete()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if u.DeletedAt.IsZero() {
+		t.Fatal("expected DeletedAt to be set, got zero time")
+	}
+	if len(u.UncommittedEvents()) != 1 {
+		t.Fatalf("expected 1 uncommitted event, got %d", len(u.UncommittedEvents()))
+	}
+	if _, ok := u.UncommittedEvents()[0].(*event.UserDeleted); !ok {
+		t.Fatal("expected uncommitted event to be *event.UserDeleted")
+	}
+}
+
+func TestUserDelete_AlreadyDeleted(t *testing.T) {
+	addr, _ := email.New("pascal@allen.com")
+	hash := password.Create("pa$$w0rd")
+	u, _ := Register(ulid.Make(), "Pascal", "Allen", addr, hash)
+	_ = u.Delete()
+
+	err := u.Delete()
+	if err == nil {
+		t.Fatal("expected error when deleting already-deleted user, got nil")
+	}
+}
+
+func TestLoadUserFromEvents_DeterministicTimestamps(t *testing.T) {
+	id := ulid.Make()
+	registeredAt := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	events := []event.Event{
+		&event.UserRegistered{
+			Id:           id,
+			FirstName:    "Pascal",
+			LastName:     "Allen",
+			EmailAddress: "pascal@allen.com",
+			PasswordHash: "hash",
+			OccurredAt:   registeredAt,
+		},
+		&event.UserEmailAddressUpdated{
+			Id:           id,
+			EmailAddress: "thomas@allen.com",
+			OccurredAt:   updatedAt,
+		},
+	}
+
+	u := LoadUserFromEvents(events)
+
+	if !u.CreatedAt.Equal(registeredAt) {
+		t.Fatalf("expected CreatedAt %v, got %v", registeredAt, u.CreatedAt)
+	}
+	if !u.ModifiedAt.Equal(updatedAt) {
+		t.Fatalf("expected ModifiedAt %v, got %v", updatedAt, u.ModifiedAt)
+	}
+	if len(u.UncommittedEvents()) != 0 {
+		t.Fatalf("expected no uncommitted events after LoadUserFromEvents, got %d", len(u.UncommittedEvents()))
+	}
+	if u.Version() != 1 {
+		t.Fatalf("expected version 1 after 2 events, got %d", u.Version())
+	}
+}

--- a/internal/es-go/infrastructure/messaging/command_bus.go
+++ b/internal/es-go/infrastructure/messaging/command_bus.go
@@ -143,6 +143,10 @@ func (bus *RabbitMqCommandBus) messages() (<-chan amqp091.Delivery, error) {
 	return d, nil
 }
 
+// processCommand deserializes an incoming message and dispatches it to the registered handler.
+// Note: this switch couples the infrastructure layer to application-layer command types.
+// A larger system would inject a map[string]func() Command registry at startup to invert
+// this dependency — keeping the bus generic and moving command knowledge to the composition root.
 func (bus *RabbitMqCommandBus) processCommand(msg amqp091.Delivery) error {
 	var cmd Command
 
@@ -151,6 +155,10 @@ func (bus *RabbitMqCommandBus) processCommand(msg amqp091.Delivery) error {
 		cmd = &command.RegisterUser{}
 	case command.UpdateUserEmailAddress{}.CommandName():
 		cmd = &command.UpdateUserEmailAddress{}
+	case command.AssignRoleToUser{}.CommandName():
+		cmd = &command.AssignRoleToUser{}
+	case command.DeleteUser{}.CommandName():
+		cmd = &command.DeleteUser{}
 	default:
 		return fmt.Errorf("unknown command received: %s", msg.Type)
 	}

--- a/internal/es-go/infrastructure/storage/event.go
+++ b/internal/es-go/infrastructure/storage/event.go
@@ -1,5 +1,7 @@
 package storage
 
-type Event interface {
-	EventName() string
-}
+import "github.com/pascalallen/es-go/internal/es-go/domain/event"
+
+// Event is a temporary alias for domain/event.Event.
+// It will be removed in the next task once all callers use event.Event directly.
+type Event = event.Event

--- a/internal/es-go/infrastructure/storage/event.go
+++ b/internal/es-go/infrastructure/storage/event.go
@@ -1,7 +1,0 @@
-package storage
-
-import "github.com/pascalallen/es-go/internal/es-go/domain/event"
-
-// Event is a temporary alias for domain/event.Event.
-// It will be removed in the next task once all callers use event.Event directly.
-type Event = event.Event

--- a/internal/es-go/infrastructure/storage/event_store.go
+++ b/internal/es-go/infrastructure/storage/event_store.go
@@ -14,7 +14,7 @@ import (
 )
 
 type EventStore interface {
-	AppendToStream(streamId string, evt Event) error
+	AppendToStream(streamId string, expectedVersion int, events []event.Event) error
 	ReadFromStream(streamId string) ([]event.Event, error)
 	RegisterProjection(projection Projection) error
 	UnmarshalProjectionResult(name string, result interface{}) error
@@ -53,48 +53,33 @@ func NewEventStoreDb() EventStore {
 	}
 }
 
-func (s *EventStoreDb) AppendToStream(streamId string, evt Event) error {
-	ropts := esdb.ReadStreamOptions{
-		Direction: esdb.Backwards,
-		From:      esdb.End{},
+// AppendToStream persists events to a stream with optimistic concurrency.
+// expectedVersion == -1 asserts the stream does not yet exist (esdb.NoStream).
+// expectedVersion >= 0 asserts that the last persisted event has that stream revision.
+func (s *EventStoreDb) AppendToStream(streamId string, expectedVersion int, events []event.Event) error {
+	var opts esdb.AppendToStreamOptions
+	if expectedVersion == -1 {
+		opts = esdb.AppendToStreamOptions{ExpectedRevision: esdb.NoStream{}}
+	} else {
+		opts = esdb.AppendToStreamOptions{ExpectedRevision: esdb.Revision(uint64(expectedVersion))}
 	}
 
-	stream, err := s.client.ReadStream(context.Background(), streamId, ropts, 1)
-	if err != nil {
-		return fmt.Errorf("failed to read from stream for last event: %s", err)
-	}
-
-	defer stream.Close()
-
-	lastEvent, err := stream.Recv()
-	if err, ok := esdb.FromError(err); !ok {
-		if err.Code() == esdb.ErrorCodeResourceNotFound {
-			log.Printf("last event stream not found when attempting to append with stream ID: %s", streamId)
-		} else {
-			return fmt.Errorf("failed to get last event from stream: %s", err)
+	var eventDataSlice []esdb.EventData
+	for _, e := range events {
+		data, err := json.Marshal(e)
+		if err != nil {
+			return fmt.Errorf("failed to marshal event %s: %s", e.EventName(), err)
 		}
+		eventDataSlice = append(eventDataSlice, esdb.EventData{
+			ContentType: esdb.ContentTypeJson,
+			EventType:   e.EventName(),
+			Data:        data,
+		})
 	}
 
-	data, err := json.Marshal(evt)
+	_, err := s.client.AppendToStream(context.Background(), streamId, opts, eventDataSlice...)
 	if err != nil {
-		return fmt.Errorf("failed to marshal event for stream: %s", err)
-	}
-
-	opts := esdb.AppendToStreamOptions{}
-	if lastEvent != nil {
-		opts = esdb.AppendToStreamOptions{
-			ExpectedRevision: lastEvent.OriginalStreamRevision(),
-		}
-	}
-	eventData := esdb.EventData{
-		ContentType: esdb.ContentTypeJson,
-		EventType:   evt.EventName(),
-		Data:        data,
-	}
-
-	_, err = s.client.AppendToStream(context.Background(), streamId, opts, eventData)
-	if err != nil {
-		return fmt.Errorf("failed to append event to stream: %s", err)
+		return fmt.Errorf("failed to append events to stream: %s", err)
 	}
 
 	return nil

--- a/internal/es-go/infrastructure/storage/event_store.go
+++ b/internal/es-go/infrastructure/storage/event_store.go
@@ -14,8 +14,8 @@ import (
 )
 
 type EventStore interface {
-	AppendToStream(streamId string, event Event) error
-	ReadFromStream(streamId string) ([]Event, error)
+	AppendToStream(streamId string, evt Event) error
+	ReadFromStream(streamId string) ([]event.Event, error)
 	RegisterProjection(projection Projection) error
 	UnmarshalProjectionResult(name string, result interface{}) error
 }
@@ -53,7 +53,7 @@ func NewEventStoreDb() EventStore {
 	}
 }
 
-func (s *EventStoreDb) AppendToStream(streamId string, event Event) error {
+func (s *EventStoreDb) AppendToStream(streamId string, evt Event) error {
 	ropts := esdb.ReadStreamOptions{
 		Direction: esdb.Backwards,
 		From:      esdb.End{},
@@ -75,7 +75,7 @@ func (s *EventStoreDb) AppendToStream(streamId string, event Event) error {
 		}
 	}
 
-	data, err := json.Marshal(event)
+	data, err := json.Marshal(evt)
 	if err != nil {
 		return fmt.Errorf("failed to marshal event for stream: %s", err)
 	}
@@ -88,7 +88,7 @@ func (s *EventStoreDb) AppendToStream(streamId string, event Event) error {
 	}
 	eventData := esdb.EventData{
 		ContentType: esdb.ContentTypeJson,
-		EventType:   event.EventName(),
+		EventType:   evt.EventName(),
 		Data:        data,
 	}
 
@@ -100,8 +100,8 @@ func (s *EventStoreDb) AppendToStream(streamId string, event Event) error {
 	return nil
 }
 
-func (s *EventStoreDb) ReadFromStream(streamId string) ([]Event, error) {
-	var events []Event
+func (s *EventStoreDb) ReadFromStream(streamId string) ([]event.Event, error) {
+	var events []event.Event
 	position := esdb.Revision(0)
 
 	for {
@@ -119,33 +119,37 @@ func (s *EventStoreDb) ReadFromStream(streamId string) ([]Event, error) {
 
 		for {
 			evt, err := stream.Recv()
-			if err, ok := esdb.FromError(err); !ok {
+			if err != nil {
 				if errors.Is(err, io.EOF) {
 					break
 				}
-
-				if err, ok := esdb.FromError(err); !ok {
-					return events, fmt.Errorf("error attempting to stream incoming event: %s", err)
-				}
+				stream.Close()
+				return events, fmt.Errorf("error attempting to stream incoming event: %s", err)
 			}
 
-			var e Event
+			var e event.Event
 			switch evt.OriginalEvent().EventType {
 			case event.UserRegistered{}.EventName():
 				e = &event.UserRegistered{}
 			case event.UserEmailAddressUpdated{}.EventName():
 				e = &event.UserEmailAddressUpdated{}
+			case event.UserPasswordSet{}.EventName():
+				e = &event.UserPasswordSet{}
+			case event.UserRoleAssigned{}.EventName():
+				e = &event.UserRoleAssigned{}
+			case event.UserDeleted{}.EventName():
+				e = &event.UserDeleted{}
 			default:
+				stream.Close()
 				return events, fmt.Errorf("unknown event retrieved: %s", evt.OriginalEvent().EventType)
 			}
 
-			err = json.Unmarshal(evt.OriginalEvent().Data, &e)
-			if err != nil {
+			if err = json.Unmarshal(evt.OriginalEvent().Data, e); err != nil {
+				stream.Close()
 				return events, fmt.Errorf("failed to unmarshal event: %s", err)
 			}
 
 			events = append(events, e)
-
 			position = esdb.Revision(evt.OriginalEvent().EventNumber + 1)
 			hasMoreEvents = true
 		}


### PR DESCRIPTION
Closes #9

## Summary

- Fix all critical ES/DDD/CQRS pattern violations in the `es-go` boilerplate
- Introduce the aggregate factory + uncommitted-events pattern so the `User` aggregate owns all invariants and event production
- Add `OccurredAt time.Time` to every event for deterministic state replay
- Move `Event` interface to the domain layer (infrastructure no longer bleeds into domain)
- Wire in password hashing, role assignment, and user deletion end-to-end
- Replace the backwards read-before-write in `AppendToStream` with version-based optimistic concurrency

## What changed

| Area | Change |
|---|---|
| `domain/event/event.go` | New — `Event` interface lives in domain, not infrastructure |
| `domain/email/` | New — `EmailAddress` value object with RFC 5322 validation |
| `domain/event/user.go` | `OccurredAt` on all events; new `UserPasswordSet`, `UserRoleAssigned`, `UserDeleted` |
| `domain/user/user.go` | Full rewrite — `Register` factory, `uncommittedEvents`, `version`, five aggregate methods |
| `domain/user/user_test.go` | New — aggregate behaviour tests (happy paths + guard conditions + deterministic replay) |
| `application/command/user.go` | `Password` added to `RegisterUser`; new `AssignRoleToUser`, `DeleteUser` commands |
| `application/command_handler/user.go` | Rebuilt — all handlers load aggregate → call method → `AppendToStream(id, version, events)` |
| `application/command_handler/projection_state.go` | New — extracted `ProjectionState` |
| `infrastructure/storage/event_store.go` | Version-based `AppendToStream`; new event cases in `ReadFromStream`; fixed nested error check |
| `infrastructure/storage/event.go` | Deleted — was a temporary alias; domain `event.Event` used directly |
| `infrastructure/messaging/command_bus.go` | New cases for `AssignRoleToUser`, `DeleteUser`; coupling trade-off documented |
| `cmd/es-go/main.go` | Registers all 4 handlers; demo shows full register → update → assign role → delete lifecycle |
| `README.md`, `CLAUDE.md` | Updated to reflect aggregate pattern, version semantics, new commands |

## Test plan

- [x] `bin/exec go test ./...` — all packages pass
- [x] `bin/exec go build -C cmd/es-go` — binary builds clean
- [x] Spec compliance review passed per task
- [x] Code quality review passed per task
- [x] Final cross-commit review: READY TO MERGE

🤖 Generated with [Claude Code](https://claude.com/claude-code)