### PR TITLE
Upgrade Go from 1.22.1 to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 golang:1.22
+FROM --platform=linux/arm64 golang:1.26
 
 LABEL org.opencontainers.image.source=https://github.com/pascalallen/es-go
 LABEL org.opencontainers.image.description="Container image for es-go"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pascalallen/es-go
 
-go 1.22.1
+go 1.26.3
 
 require (
 	github.com/EventStore/EventStore-Client-Go/v4 v4.1.0


### PR DESCRIPTION
## Summary

- Bump `go` directive in `go.mod` from `1.22.1` → `1.26.3`
- Bump base image in `Dockerfile` from `golang:1.22` → `golang:1.26`

## Test plan

- [x] Docker image builds successfully with `golang:1.26`
- [x] `go test ./...` — all packages pass, no regressions
- [x] `go vet ./...` — clean

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)